### PR TITLE
#53 Configurar cobertura de testes nos microsserviços

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 
 # testing
 /coverage
+test-report.xml
 
 # production
 /build

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "jest",
+    "test": "jest --coverage",
     "start": "node index.js"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,16 @@
   },
   "homepage": "https://github.com/fga-eps-mds/2021.1-Oraculo-Processos#readme",
   "devDependencies": {
-    "jest": "^27.1.1"
+    "jest": "^27.1.1",
+    "jest-sonar-reporter": "^2.0.0"
+  },
+  "jest": {
+    "testEnvironment": "node",
+    "collectCoverage": true,
+    "testResultsProcessor": "jest-sonar-reporter",
+    "coveragePathIgnorePatterns": [
+      "/node_modules/",
+      "/test/"
+    ]
   }
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,3 +7,6 @@ sonar.language=js
 sonar.tests=./tests
 
 sonar.javascript.lcov.reportPaths=./coverage/lcov.info
+sonar.testExecutionReportPaths=./test-report.xml
+
+sonar.sourceEncoding=UTF-8

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,2 +1,9 @@
 sonar.organization=fga-eps-mds-1
 sonar.projectKey=fga-eps-mds_2021.1-Oraculo-Processos
+
+sonar.sources=.
+sonar.exclusions=**/tests/*.js
+sonar.language=js
+sonar.tests=./tests
+
+sonar.javascript.lcov.reportPaths=./coverage/lcov.info


### PR DESCRIPTION
**Issue:** [fga-eps-mds/2021.1-Oraculo#53](https://github.com/fga-eps-mds/2021.1-Oraculo/issues/53)

## Descrição

Apesar de o teste ser realizado, não há coleta de métricas de teste.

Os arquivos foram atualizados para coletar as métricas.